### PR TITLE
Correctly handle line separators

### DIFF
--- a/gensrc/src/main/java/dyvilx/tools/gensrc/lexer/GenSrcLexer.java
+++ b/gensrc/src/main/java/dyvilx/tools/gensrc/lexer/GenSrcLexer.java
@@ -111,6 +111,12 @@ public class GenSrcLexer extends dyvilx.tools.parsing.lexer.Lexer
 				}
 				this.braceLevel--;
 				break;
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
 			case '\n':
 				// end at newline, but include it
 				this.newLine();
@@ -213,9 +219,17 @@ public class GenSrcLexer extends dyvilx.tools.parsing.lexer.Lexer
 
 	private void skipNewLine()
 	{
-		if (this.codePoint() == '\n')
+		switch (this.codePoint())
 		{
+		case '\r':
+			if (this.nextCodePoint() == '\n')
+			{
+				this.advance();
+			}
+			// fallthrough
+		case '\n':
 			this.newLine();
+			break;
 		}
 	}
 
@@ -223,13 +237,20 @@ public class GenSrcLexer extends dyvilx.tools.parsing.lexer.Lexer
 	{
 		while (current != 0 && Character.isWhitespace(current))
 		{
-			if (current == '\n')
+			switch (current)
 			{
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
+			case '\n':
 				this.newLine();
-			}
-			else
-			{
+				break;
+			default:
 				this.advance(current);
+				break;
 			}
 
 			current = this.codePoint();

--- a/library/src/main/dyvil/dyvilx/tools/gensrc/Builtins.dyv
+++ b/library/src/main/dyvil/dyvilx/tools/gensrc/Builtins.dyv
@@ -79,8 +79,8 @@ abstract class Builtins {
 
 	static func decorate(with process: String -> String, _ body: String) -> String {
 		let result = new StringBuilder
-		for line <- body.split('\n') {
-			result.append(process(line)).append('\n')
+		for line <- body.split('\n|\r\n?') {
+			result.append(process(line)).append(System.lineSeparator)
 		}
 		return result.toString
 	}

--- a/library/src/main/java/dyvilx/tools/parsing/lexer/DyvilLexer.java
+++ b/library/src/main/java/dyvilx/tools/parsing/lexer/DyvilLexer.java
@@ -157,6 +157,12 @@ public final class DyvilLexer extends Lexer
 		case '9':
 			this.parseNumberLiteral(currentChar);
 			return;
+		case '\r':
+			if (this.nextCodePoint() == '\n')
+			{
+				this.advance();
+			}
+			// fallthrough
 		case '\n':
 			this.newLine();
 			return;
@@ -194,6 +200,12 @@ public final class DyvilLexer extends Lexer
 			final int currentChar = this.codePoint();
 			switch (currentChar)
 			{
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
 			case '\n':
 				this.newLine();
 				continue;
@@ -245,6 +257,12 @@ public final class DyvilLexer extends Lexer
 			case '\b':
 				this.advance();
 				continue;
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
 			case '\n':
 				this.newLine();
 				this.error("string.single.newline");
@@ -315,6 +333,12 @@ public final class DyvilLexer extends Lexer
 					new StringToken(this.buffer.toString(), stringPart ? STRING_END : STRING, startLine, this.line,
 					                startColumn, this.column));
 				return;
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
 			case '\n':
 				this.newLine();
 				break;
@@ -362,6 +386,12 @@ public final class DyvilLexer extends Lexer
 					new StringToken(this.buffer.toString(), VERBATIM_STRING, startLine, this.line, startColumn,
 					                this.column));
 				return;
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
 			case '\n':
 				this.newLine();
 				continue;
@@ -392,6 +422,15 @@ public final class DyvilLexer extends Lexer
 		{
 		case '\\':
 			this.parseEscape(this.nextCodePoint());
+			break;
+		case '\r':
+			this.buffer.append('\r');
+			if (this.nextCodePoint() == '\n')
+			{
+				this.advance();
+				this.error("char.verbatim.invalid");
+			}
+			this.newLine();
 			break;
 		case '\n':
 			this.buffer.append('\n');
@@ -685,6 +724,12 @@ public final class DyvilLexer extends Lexer
 			{
 			case EOF:
 				return;
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
 			case '\n':
 				this.newLine();
 				return;
@@ -711,6 +756,12 @@ public final class DyvilLexer extends Lexer
 			case EOF:
 				this.error("comment.block.unclosed");
 				return;
+			case '\r':
+				if (this.nextCodePoint() == '\n')
+				{
+					this.advance();
+				}
+				// fallthrough
 			case '\n':
 				this.newLine();
 				continue;
@@ -911,6 +962,12 @@ public final class DyvilLexer extends Lexer
 				int codePoint = this.codePoint();
 				switch (codePoint)
 				{
+				case '\r':
+					if (this.nextCodePoint() == '\n')
+					{
+						this.advance();
+					}
+					// fallthrough
 				case '\n':
 					this.error("escape.unicode.newline");
 					this.newLine();


### PR DESCRIPTION
## Library

### Bugfixes

* The `DyvilLexer` correctly handles `\r` and `\r\n` line separators now.
* The `Builtins.decorate` method correctly handles `\r` and `\r\n` line separators now.

## GenSrc

### Bugfixes

* The GenSrc lexer correctly handles `\r` and `\r\n` line separators now.