### PR TITLE
Remove Deprecated Syntax

### DIFF
--- a/compiler/src/main/java/dyvilx/tools/compiler/ast/method/CodeMethod.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/ast/method/CodeMethod.java
@@ -312,21 +312,21 @@ public class CodeMethod extends AbstractMethod
 		{
 			if (explicitParameters != 1)
 			{
-				markers.add(Markers.semanticWarning(this.position, "method.prefix.not_1_parameter.deprecated", this.name));
+				markers.add(Markers.semanticError(this.position, "method.prefix.not_unary", this.name));
 			}
 		}
 		else if (fixity == Modifiers.POSTFIX)
 		{
 			if (explicitParameters != 1)
 			{
-				markers.add(Markers.semanticWarning(this.position, "method.postfix.not_1_parameter.deprecated", this.name));
+				markers.add(Markers.semanticError(this.position, "method.postfix.not_unary", this.name));
 			}
 		}
 		else if (fixity == Modifiers.INFIX)
 		{
 			if (explicitParameters != 2)
 			{
-				markers.add(Markers.semanticWarning(this.position, "method.infix.not_2_parameters.deprecated", this.name));
+				markers.add(Markers.semanticError(this.position, "method.infix.not_binary", this.name));
 			}
 		}
 	}

--- a/compiler/src/main/java/dyvilx/tools/compiler/ast/method/CodeMethod.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/ast/method/CodeMethod.java
@@ -172,40 +172,10 @@ public class CodeMethod extends AbstractMethod
 		{
 			this.value = this.value.resolve(markers, context);
 
-			boolean inferType = false;
-			if (this.type == Types.UNKNOWN || this.type == null)
-			{
-				inferType = true;
-				this.type = this.value.getType();
-				if (this.type == Types.UNKNOWN && this.value.isResolved())
-				{
-					markers.add(Markers.semanticError(this.position, "method.type.infer", this.name.unqualified));
-				}
-			}
-
 			final TypeChecker.MarkerSupplier markerSupplier = TypeChecker.markerSupplier("method.type.incompatible",
 			                                                                             "method.type", "value.type",
 			                                                                             this.name);
 			this.value = TypeChecker.convertValue(this.value, this.type, null, markers, context, markerSupplier);
-
-			if (inferType)
-			{
-				this.type = this.value.getType();
-
-				if (this.type.getTypecode() != PrimitiveType.VOID_CODE)
-				{
-					final Marker marker = Markers.semanticWarning(this.position, "method.type.infer.deprecated");
-					final StringBuilder typeString = new StringBuilder();
-					this.type.toString("", typeString);
-					marker.addInfo(Markers.getSemantic("method.type.infer.deprecated.fix", typeString.toString()));
-					markers.add(marker);
-				}
-			}
-		}
-		else if (this.type == Types.UNKNOWN)
-		{
-			markers.add(Markers.semanticError(this.position, "method.type.abstract", this.name.unqualified));
-			this.type = Types.ANY;
 		}
 
 		context.pop();

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/classes/MethodParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/classes/MethodParser.java
@@ -98,12 +98,8 @@ public class MethodParser extends AbstractMemberParser
 			}
 			// Fallthrough
 		case TYPE:
-			switch (type)
+			if (type == DyvilSymbols.ARROW_RIGHT)
 			{
-			case BaseSymbols.COLON:
-				pm.report(Markers.syntaxWarning(token, "method.type.colon.deprecated"));
-				// Fallthrough
-			case DyvilSymbols.ARROW_RIGHT:
 				pm.pushParser(new TypeParser(this.method::setType));
 				this.mode = EXCEPTIONS;
 				return;

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/classes/MethodParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/classes/MethodParser.java
@@ -75,7 +75,7 @@ public class MethodParser extends AbstractMemberParser
 				return;
 			}
 
-			this.method = this.consumer.createMethod(token.raw(), token.nameValue(), Types.UNKNOWN, this.attributes);
+			this.method = this.consumer.createMethod(token.raw(), token.nameValue(), Types.VOID, this.attributes);
 
 			this.mode = GENERICS;
 			return;

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/expression/ExpressionParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/expression/ExpressionParser.java
@@ -988,11 +988,7 @@ public class ExpressionParser extends Parser implements Consumer<IValue>
 		case DyvilKeywords.TRY:
 		{
 			// try ...
-
-			final TryStatement tryStatement = new TryStatement(token.raw());
-			this.value = tryStatement;
-
-			pm.pushParser(new TryStatementParser(tryStatement));
+			pm.pushParser(new TryStatementParser(this));
 			this.mode = END;
 			return true;
 		}

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/expression/ExpressionParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/expression/ExpressionParser.java
@@ -919,7 +919,7 @@ public class ExpressionParser extends Parser implements Consumer<IValue>
 			final WhileStatement whileStatement = new WhileStatement(token.raw());
 			this.value = whileStatement;
 
-			pm.pushParser(new WhileStatementParser(whileStatement));
+			pm.pushParser(new WhileStatementParser(whileStatement), true);
 			this.mode = END;
 			return true;
 		}
@@ -930,7 +930,7 @@ public class ExpressionParser extends Parser implements Consumer<IValue>
 			final RepeatStatement repeatStatement = new RepeatStatement(token.raw());
 			this.value = repeatStatement;
 
-			pm.pushParser(new RepeatStatementParser(repeatStatement));
+			pm.pushParser(new RepeatStatementParser(repeatStatement), true);
 			this.mode = END;
 			return true;
 		}
@@ -988,7 +988,7 @@ public class ExpressionParser extends Parser implements Consumer<IValue>
 		case DyvilKeywords.TRY:
 		{
 			// try ...
-			pm.pushParser(new TryStatementParser(this));
+			pm.pushParser(new TryStatementParser(this), true);
 			this.mode = END;
 			return true;
 		}
@@ -1032,7 +1032,7 @@ public class ExpressionParser extends Parser implements Consumer<IValue>
 			final SyncStatement syncStatement = new SyncStatement(token.raw());
 			this.value = syncStatement;
 
-			pm.pushParser(new SyncStatementParser(syncStatement));
+			pm.pushParser(new SyncStatementParser(syncStatement), true);
 			this.mode = END;
 			return true;
 		}

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/header/OperatorParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/header/OperatorParser.java
@@ -226,11 +226,6 @@ public final class OperatorParser extends Parser
 		{
 			return token.nameValue();
 		}
-		if (type == Tokens.LETTER_IDENTIFIER)
-		{
-			pm.report(Markers.syntaxWarning(token, "operator.identifier.not_symbol"));
-			return token.nameValue();
-		}
 		if ((type & Tokens.SYMBOL) != 0)
 		{
 			return Name.from(DyvilSymbols.INSTANCE.toString(type));

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/ForStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/ForStatementParser.java
@@ -26,10 +26,10 @@ public class ForStatementParser extends Parser implements IDataMemberConsumer<IV
 {
 	// =============== Constants ===============
 
-	private static final int FOR                = 0;
-	private static final int VARIABLE           = 1 << 1;
-	private static final int VARIABLE_SEPARATOR = 1 << 2;
-	private static final int STATEMENT          = 1 << 7;
+	private static final int FOR = 1;
+	private static final int VARIABLE = 2;
+	private static final int VARIABLE_SEPARATOR = 3;
+	private static final int STATEMENT = 4;
 
 	// =============== Fields ===============
 
@@ -42,7 +42,7 @@ public class ForStatementParser extends Parser implements IDataMemberConsumer<IV
 	public ForStatementParser(Consumer<IValue> consumer)
 	{
 		this.consumer = consumer;
-		// this.mode = FOR;
+		this.mode = FOR;
 	}
 
 	// =============== Methods ===============

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/ForStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/ForStatementParser.java
@@ -89,13 +89,6 @@ public class ForStatementParser extends Parser implements IDataMemberConsumer<IV
 		}
 	}
 
-	static void reportSingleStatement(IParserManager pm, IToken token, String key)
-	{
-		final Marker marker = Markers.syntaxWarning(SourcePosition.before(token), key);
-		marker.addInfo(Markers.getSyntax("statement.single.deprecated.fix"));
-		pm.report(marker);
-	}
-
 	@Override
 	public void addDataMember(IVariable dataMember)
 	{

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/ForStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/ForStatementParser.java
@@ -17,8 +17,6 @@ import dyvilx.tools.compiler.parser.expression.ExpressionParser;
 import dyvilx.tools.compiler.util.Markers;
 import dyvilx.tools.parsing.IParserManager;
 import dyvilx.tools.parsing.Parser;
-import dyvilx.tools.parsing.lexer.BaseSymbols;
-import dyvilx.tools.parsing.lexer.Tokens;
 import dyvilx.tools.parsing.marker.Marker;
 import dyvilx.tools.parsing.token.IToken;
 
@@ -81,26 +79,10 @@ public class ForStatementParser extends Parser implements IDataMemberConsumer<IV
 				              .withFlags(ExpressionParser.IGNORE_CLOSURE));
 			return;
 		case STATEMENT:
-			switch (type)
-			{
-			case BaseSymbols.SEMICOLON:
-			case BaseSymbols.CLOSE_CURLY_BRACKET:
-				pm.reparse();
-				// Fallthrough
-			case Tokens.EOF:
-				pm.popParser();
-				this.consumer.accept(this.forStatement);
-				return;
-			case BaseSymbols.OPEN_CURLY_BRACKET:
-				pm.pushParser(new StatementListParser(this.forStatement::setAction), true);
-				this.mode = END;
-				return;
-			default:
-				reportSingleStatement(pm, token, "for.single.deprecated");
-				pm.pushParser(new ExpressionParser(this.forStatement::setAction), true);
-				this.mode = END;
-				return;
-			}
+			pm.pushParser(new StatementListParser(this.forStatement::setAction), true);
+			this.mode = END;
+			return;
+			// Fallthrough
 		case END:
 			pm.popParser(true);
 			this.consumer.accept(this.forStatement);

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/IfStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/IfStatementParser.java
@@ -55,14 +55,13 @@ public class IfStatementParser extends Parser implements IDataMemberConsumer<IVa
 		switch (this.mode)
 		{
 		case IF:
-			if (type != DyvilKeywords.IF)
-			{
-				pm.report(token, "if.keyword");
-				return;
-			}
-
 			this.mode = CONDITION_PART;
 			this.statement = new IfStatement(token.raw());
+			if (type != DyvilKeywords.IF)
+			{
+				pm.reparse();
+				pm.report(token, "if.keyword");
+			}
 			return;
 		case CONDITION_PART:
 			if (type == DyvilKeywords.LET)

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/IfStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/IfStatementParser.java
@@ -96,16 +96,17 @@ public class IfStatementParser extends Parser implements IDataMemberConsumer<IVa
 			pm.pushParser(new StatementListParser(this.statement::setThen), true);
 			return;
 		case ELSE:
-			final IToken next = token.next();
-			if (token.isInferred() && next.type() == DyvilKeywords.ELSE)
+			switch (type)
 			{
-				// inferred semicolon between } and else
-				return;
-			}
-
-			if (type == DyvilKeywords.ELSE)
-			{
-				final int nextType = next.type();
+			case BaseSymbols.SEMICOLON:
+				if (token.isInferred() && token.next().type() == DyvilKeywords.ELSE)
+				{
+					// inferred semicolon between } and else
+					return;
+				}
+				break; // end
+			case DyvilKeywords.ELSE:
+				final int nextType = token.next().type();
 				if (nextType == DyvilKeywords.IF)
 				{
 					pm.pushParser(new IfStatementParser(this.statement::setElse));

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/RepeatStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/RepeatStatementParser.java
@@ -49,18 +49,18 @@ public class RepeatStatementParser extends Parser
 			this.mode = WHILE;
 			return;
 		case WHILE:
-			if (type == DyvilKeywords.WHILE)
+			switch (type)
 			{
-				this.mode = END;
-				pm.pushParser(new ExpressionParser(this.statement::setCondition));
-				return;
-			}
-			if (type == BaseSymbols.SEMICOLON && token.isInferred() && token.next().type() == DyvilKeywords.WHILE)
-			{
-				this.mode = END;
-				pm.skip(1);
-				pm.pushParser(new ExpressionParser(this.statement::setCondition));
-				return;
+				case BaseSymbols.SEMICOLON:
+					if (token.isInferred() && token.next().type() == DyvilKeywords.WHILE)
+					{
+						return;
+					}
+					break; // end
+				case DyvilKeywords.WHILE:
+					this.mode = END;
+					pm.pushParser(new ExpressionParser(this.statement::setCondition));
+					return;
 			}
 			// fallthrough
 		case END:

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/RepeatStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/RepeatStatementParser.java
@@ -12,9 +12,9 @@ public class RepeatStatementParser extends Parser
 {
 	// =============== Constants ===============
 
-	protected static final int REPEAT = 1;
-	protected static final int ACTION = 2;
-	protected static final int WHILE  = 3;
+	private static final int REPEAT = 1;
+	private static final int ACTION = 2;
+	private static final int WHILE = 3;
 
 	// =============== Fields ===============
 
@@ -25,7 +25,7 @@ public class RepeatStatementParser extends Parser
 	public RepeatStatementParser(RepeatStatement statement)
 	{
 		this.statement = statement;
-		this.mode = ACTION;
+		this.mode = REPEAT;
 	}
 
 	// =============== Methods ===============

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/RepeatStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/RepeatStatementParser.java
@@ -45,12 +45,7 @@ public class RepeatStatementParser extends Parser
 			}
 			return;
 		case ACTION:
-			if (type != BaseSymbols.OPEN_CURLY_BRACKET)
-			{
-				ForStatementParser.reportSingleStatement(pm, token, "repeat.single.deprecated");
-			}
-
-			pm.pushParser(new ExpressionParser(this.statement::setAction), true);
+			pm.pushParser(new StatementListParser(this.statement::setAction), true);
 			this.mode = WHILE;
 			return;
 		case WHILE:

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/SyncStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/SyncStatementParser.java
@@ -52,17 +52,7 @@ public class SyncStatementParser extends Parser
 			this.mode = ACTION;
 			return;
 		case ACTION:
-			if (BaseSymbols.isTerminator(type) && !token.isInferred())
-			{
-				pm.popParser(true);
-				return;
-			}
-			if (type != BaseSymbols.OPEN_CURLY_BRACKET)
-			{
-				ForStatementParser.reportSingleStatement(pm, token, "synchronized.single.deprecated");
-			}
-
-			pm.pushParser(new ExpressionParser(this.statement::setAction), true);
+			pm.pushParser(new StatementListParser(this.statement::setAction), true);
 			this.mode = END;
 			return;
 		case END:

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/SyncStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/SyncStatementParser.java
@@ -39,13 +39,12 @@ public class SyncStatementParser extends Parser
 		switch (this.mode)
 		{
 		case SYNCHRONIZED:
+			this.mode = LOCK;
 			if (type != DyvilKeywords.SYNCHRONIZED)
 			{
+				pm.reparse();
 				pm.report(token, "synchronized.keyword");
-				return;
 			}
-
-			this.mode = LOCK;
 			return;
 		case LOCK:
 			pm.pushParser(new ExpressionParser(this.statement::setLock).withFlags(IGNORE_STATEMENT), true);

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/SyncStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/SyncStatementParser.java
@@ -15,8 +15,8 @@ public class SyncStatementParser extends Parser
 	// =============== Constants ===============
 
 	private static final int SYNCHRONIZED = 0;
-	private static final int LOCK         = 1;
-	private static final int ACTION       = 2;
+	private static final int LOCK = 1;
+	private static final int ACTION = 2;
 
 	// =============== Fields ===============
 
@@ -27,7 +27,7 @@ public class SyncStatementParser extends Parser
 	public SyncStatementParser(SyncStatement statement)
 	{
 		this.statement = statement;
-		this.mode = LOCK;
+		this.mode = SYNCHRONIZED;
 	}
 
 	// =============== Methods ===============

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/TryStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/TryStatementParser.java
@@ -39,7 +39,7 @@ public class TryStatementParser extends Parser implements IDataMemberConsumer<IV
 	public TryStatementParser(Consumer<? super TryStatement> consumer)
 	{
 		this.consumer = consumer;
-		this.mode = ACTION;
+		this.mode = TRY;
 	}
 
 	// =============== Methods ===============

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/TryStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/TryStatementParser.java
@@ -51,14 +51,13 @@ public class TryStatementParser extends Parser implements IDataMemberConsumer<IV
 		switch (this.mode)
 		{
 		case TRY:
-			if (type != DyvilKeywords.TRY)
-			{
-				pm.report(token, "try.keyword");
-				return;
-			}
-
 			this.mode = ACTION;
 			this.statement = new TryStatement(token.raw());
+			if (type != DyvilKeywords.TRY)
+			{
+				pm.reparse();
+				pm.report(token, "try.keyword");
+			}
 			return;
 		case ACTION:
 			pm.pushParser(new StatementListParser(this.statement::setAction), true);

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/WhileStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/WhileStatementParser.java
@@ -14,9 +14,9 @@ public class WhileStatementParser extends Parser
 {
 	// =============== Constants ===============
 
-	protected static final int WHILE     = 0;
-	protected static final int CONDITION = 1;
-	protected static final int ACTION    = 2;
+	private static final int WHILE = 0;
+	private static final int CONDITION = 1;
+	private static final int ACTION = 2;
 
 	// =============== Fields ===============
 
@@ -27,7 +27,7 @@ public class WhileStatementParser extends Parser
 	public WhileStatementParser(WhileStatement statement)
 	{
 		this.statement = statement;
-		this.mode = CONDITION;
+		this.mode = WHILE;
 	}
 
 	// =============== Methods ===============

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/WhileStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/WhileStatementParser.java
@@ -52,16 +52,7 @@ public class WhileStatementParser extends Parser
 			this.mode = ACTION;
 			return;
 		case ACTION:
-			if (BaseSymbols.isTerminator(type) && !token.isInferred())
-			{
-				pm.popParser(true);
-				return;
-			}
-			if (type != BaseSymbols.OPEN_CURLY_BRACKET)
-			{
-				ForStatementParser.reportSingleStatement(pm, token, "while.single.deprecated");
-			}
-			pm.pushParser(new ExpressionParser(this.statement::setAction), true);
+			pm.pushParser(new StatementListParser(this.statement::setAction), true);
 			this.mode = END;
 			return;
 		case END:

--- a/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/WhileStatementParser.java
+++ b/compiler/src/main/java/dyvilx/tools/compiler/parser/statement/WhileStatementParser.java
@@ -39,13 +39,12 @@ public class WhileStatementParser extends Parser
 		switch (this.mode)
 		{
 		case WHILE:
+			this.mode = CONDITION;
 			if (type != DyvilKeywords.WHILE)
 			{
+				pm.reparse();
 				pm.report(token, "while.keyword");
-				return;
 			}
-
-			this.mode = CONDITION;
 			return;
 		case CONDITION:
 			pm.pushParser(new ExpressionParser(this.statement::setCondition).withFlags(IGNORE_STATEMENT), true);

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SemanticMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SemanticMarkers.properties
@@ -214,10 +214,6 @@ constructor.access.array.typevar=cannot create an array of the generic type para
 method.duplicate.descriptor=duplicate method '%s' with descriptor '%s%s'
 method.type=method return type: %s
 method.type.incompatible=the return value of the method '%s' is incompatible with the return type
-method.type.infer=the type of the method '%s' could not be inferred
-method.type.infer.deprecated=method return type inference is deprecated
-method.type.infer.deprecated.fix=suppress this warning by adding '-> %s' after the parameter list
-method.type.abstract=the type of the abstract method '%s' could not be inferred
 method.exception.type=the thrown exception must be a subtype of java.lang.throwable
 
 method.this_type.incompatible=the receiver type of the method '%s' is incompatible with the enclosing class

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SemanticMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SemanticMarkers.properties
@@ -274,9 +274,9 @@ method.extension.this_type.invalid=the extension method '%s' must define a this 
 method.not_symbolic.deprecated=non-symbolic prefix, infix and postfix functions are deprecated
 method.not_symbolic.deprecated.fix=use an instance or extension method instead
 
-method.prefix.not_1_parameter.deprecated=prefix functions with more or less than one parameter are deprecated
-method.infix.not_2_parameters.deprecated=infix functions with more or less than two parameters are deprecated
-method.postfix.not_1_parameter.deprecated=postfix functions with more or less than one parameter are deprecated
+method.prefix.not_unary=prefix functions must have exactly one parameter
+method.infix.not_binary=infix functions must have exactly two parameters
+method.postfix.not_unary=postfix functions must have exactly one parameter
 
 # Parameters
 

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
@@ -219,8 +219,6 @@ if.keyword=invalid if statement - 'if' expected
 if.open_paren=invalid if statement - '(' expected
 if.close_paren=invalid if statement - ')' expected
 if.binding.assignment=invalid binding if statement - '=' expected
-if.single.deprecated=single-statement if branches are deprecated
-else.single.deprecated=single-statement else branches are deprecated
 
 # While and Repeat Loops
 
@@ -234,7 +232,6 @@ repeat.single.deprecated=single-statement repeat loops are deprecated
 
 for.keyword=invalid for loop - 'for' expected
 for.variable.separator=invalid for loop - '<-' expected after variable
-for.single.deprecated=single-statement for loops are deprecated
 
 # Synchronized Blocks
 
@@ -242,10 +239,6 @@ synchronized.keyword=invalid synchronized block - 'synchronized' expected
 synchronized.single.deprecated=single-statement synchronized blocks are deprecated
 
 # Try Statements
-
-try.single.statement=single-statement try blocks are deprecated
-catch.single.statement=single-statement catch blocks are deprecated
-finally.single.statement=single-statement finally blocks are deprecated
 
 # --------------- Patterns ---------------
 

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
@@ -92,10 +92,6 @@ field.enum.invalid=invalid enum constant declaration - enum constants can only b
 
 method.identifier=invalid method declaration - identifier expected
 method.parameters.close_paren=invalid method parameter list - ')' expected
-method.declaration.separator=invalid method declaration - ';', '=', '(', '[', '{' or 'throws' expected
-method.body.separator=invalid method declaration - ';', '=', '{' or 'throws' expected
-method.throws.comma=invalid exception list - ',' expected
-method.type.colon.deprecated=using ':' for method type ascription is deprecated; replace this token with '->'
 
 method.call.close_paren=invalid argument list - ')' expected
 method.call.generic.close_angle=invalid type argument list - '>' expected

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
@@ -33,7 +33,6 @@ import.wildcard.java=Java-style wildcard imports are discouraged; replace this t
 operator.type.invalid=invalid operator - 'infix', 'prefix' or 'postfix' expected
 operator.identifier=invalid operator - identifier expected
 operator.identifier2=invalid operator - secondary identifier expected
-operator.identifier.not_symbol=letter identifiers as operator names are deprecated
 operator.operator=invalid operator - 'operator' expected
 
 operator.prefix.associativity=invalid prefix operator - prefix operators cannot define an associativity

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
@@ -199,8 +199,6 @@ throw.expression=invalid throw statement - expression expected
 
 # --------------- Statements ---------------
 
-statement.single.deprecated.fix=suppress this warning by adding '{' and '}' around the body
-
 # Statement Lists
 
 statement_list.open_brace=invalid statement list - '{' expected
@@ -220,26 +218,16 @@ if.open_paren=invalid if statement - '(' expected
 if.close_paren=invalid if statement - ')' expected
 if.binding.assignment=invalid binding if statement - '=' expected
 
-# While and Repeat Loops
+# Loops
 
 while.keyword=invalid while loop - 'while' expected
-while.single.deprecated=single-statement while loops are deprecated
-
 repeat.keyword=invalid repeat loop - 'repeat' expected
-repeat.single.deprecated=single-statement repeat loops are deprecated
-
-# For Loops
-
 for.keyword=invalid for loop - 'for' expected
 for.variable.separator=invalid for loop - '<-' expected after variable
 
-# Synchronized Blocks
+# Other Blocks
 
 synchronized.keyword=invalid synchronized block - 'synchronized' expected
-synchronized.single.deprecated=single-statement synchronized blocks are deprecated
-
-# Try Statements
-
 try.keyword=invalid try statement - 'try' expected
 
 # --------------- Patterns ---------------

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
@@ -240,6 +240,8 @@ synchronized.single.deprecated=single-statement synchronized blocks are deprecat
 
 # Try Statements
 
+try.keyword=invalid try statement - 'try' expected
+
 # --------------- Patterns ---------------
 
 pattern.expected=invalid token '%s' - pattern expected

--- a/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
+++ b/compiler/src/main/resources/dyvilx/tools/compiler/lang/SyntaxMarkers.properties
@@ -216,7 +216,6 @@ variable.identifier=invalid variable declaration - identifier or '_' expected
 # If Statements
 
 if.keyword=invalid if statement - 'if' expected
-if.paren.deprecated=if statements with parentheses are deprecated and will be unsupported in Dyvil v0.47.0
 if.open_paren=invalid if statement - '(' expected
 if.close_paren=invalid if statement - ')' expected
 if.binding.assignment=invalid binding if statement - '=' expected
@@ -234,9 +233,7 @@ repeat.single.deprecated=single-statement repeat loops are deprecated
 # For Loops
 
 for.keyword=invalid for loop - 'for' expected
-for.paren.deprecated=for loops with parentheses are deprecated and will be unsupported in Dyvil v0.47.0
 for.variable.separator=invalid for loop - '<-' expected after variable
-for.close_paren=invalid for loop - ')' expected
 for.single.deprecated=single-statement for loops are deprecated
 
 # Synchronized Blocks
@@ -247,8 +244,6 @@ synchronized.single.deprecated=single-statement synchronized blocks are deprecat
 # Try Statements
 
 try.single.statement=single-statement try blocks are deprecated
-catch.paren.deprecated=catch blocks with parentheses are deprecated and will be unsupported in Dyvil v0.47.0
-catch.close_paren=invalid catch block - ')' expected"
 catch.single.statement=single-statement catch blocks are deprecated
 finally.single.statement=single-statement finally blocks are deprecated
 


### PR DESCRIPTION
## Removals

- Removed method return type inferences.
  > Methods without a return type annotation are implicitly `void`.
- Dropped support for parenthesized `if`, `for` and `catch`. #487
  > Note that some forms are still allowed when considering the parentheses as part of an expression, e.g. `if (true && false) {}`.
  > However, binding if statements, for loops and catch blocks, do not allow parentheses at all.
- Dropped support for `if`, `for`, `try`, `catch`, `finally`, `repeat`, `synchronized` and `while` without a block `{ }`. #473
- Dropped support for alphanumeric identifiers in operator declarations.
- Dropped support for `prefix`, `postfix` and `infix` methods with an incorrect number of parameters.
  > This used to be a warning, but is now an error.